### PR TITLE
Revert "GH-76: Install-ISHDotNetHosting - Prerequisite for 14.0.3"

### DIFF
--- a/Source/Modules/ISHServer/Get-ISHPrerequisites.ps1
+++ b/Source/Modules/ISHServer/Get-ISHPrerequisites.ps1
@@ -112,13 +112,17 @@ function Get-ISHPrerequisites {
             $filesToDownload += Get-Variable -Name "ISHServer:MSXML" -ValueOnly
         }
 
+        #Only for 15
+        if ($PSCmdlet.MyInvocation.MyCommand.Module.Name -eq "ISHServer.15") {
+            $filesToDownload += Get-Variable -Name "ISHServer:DotNetHosting" -ValueOnly
+        }
+
         #Only for 14 and 15
         if (($PSCmdlet.MyInvocation.MyCommand.Module.Name -eq "ISHServer.14") -or ($PSCmdlet.MyInvocation.MyCommand.Module.Name -eq "ISHServer.15")) {
             $filesToDownload += Get-Variable -Name "ISHServer:AdoptOpenJDK" -ValueOnly
             $filesToDownload += Get-Variable -Name "ISHServer:AdoptOpenJRE" -ValueOnly
             $filesToDownload += Get-Variable -Name "ISHServer:MSOLEDBSQL" -ValueOnly
             $filesToDownload += "$(Get-Variable -Name "ISHServer:Oracle19" -ValueOnly).zip"
-            $filesToDownload += Get-Variable -Name "ISHServer:DotNetHosting" -ValueOnly
         }
 
         #Dependend on Operating System Information (OS Server vesion, already installed prerequisites)

--- a/Source/Modules/ISHServer/ISHServer.14.psm1
+++ b/Source/Modules/ISHServer/ISHServer.14.psm1
@@ -30,7 +30,6 @@ Set-Variable -Name "ISHServer:NETFramework" -Value "NETFramework2017_4.7.2.xxxxx
 Set-Variable -Name "ISHServer:VisualBasicRuntime" -Value "vbrun60sp6.exe" -Scope "Script" -Option Constant
 Set-Variable -Name "ISHServer:MSOLEDBSQLRequiredVersion" -Value "18.2.1.0" -Scope "Script" -Option Constant
 Set-Variable -Name "ISHServer:MSOLEDBSQL" -Value "msoledbsql_18.3.0.0_x64.msi" -Scope "Script" -Option Constant
-Set-Variable -Name "ISHServer:DotNetHosting" -Value "dotnet-hosting-3.1.5-win.exe"  -Scope "Script" -Option Constant
 #Set-Variable -Name "ISHServer:MSXML" -Value "MSXML.40SP3.msi" -Scope "Script" -Option Constant
 
 $exportNames=@(
@@ -80,7 +79,6 @@ $exportNames=@(
     "Install-ISHWindowsFeatureIISWinAuth"
     "Install-ISHVisualBasicRuntime"
     "Install-ISHToolMSOLEDBSQL"
-    "Install-ISHDotNetHosting"
     #endregion
 
     #region Regional settings


### PR DESCRIPTION
Reverts PR sdl/ISHServer#77 and Issue #76 
Reverted since .NET Core 3.1 (Hosting Bundle) is no longer a requirement for 14.0.3