### PR TITLE
Revert "GH-76 - DotnetHosting: Bump version, update relase notes"

### DIFF
--- a/Automation/Publish-Module.ps1
+++ b/Automation/Publish-Module.ps1
@@ -38,8 +38,8 @@ switch ($PSCmdlet.ParameterSetName)
     'Public+Internal' {
         $publishDebug=$true
         $repository=$DevRepository
-        #$moduleNamesToPublish+="ISHServer.12"
-        #$moduleNamesToPublish+="ISHServer.13"
+        $moduleNamesToPublish+="ISHServer.12"
+        $moduleNamesToPublish+="ISHServer.13"
         $moduleNamesToPublish+="ISHServer.14"
         $moduleNamesToPublish+="ISHServer.15"
         break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-**1.9**
-
-Issues:
-- GH-76: Add support for the installation of Microsoft .NET Core - Windows Server Hosting v3.1.5 (ISHServer.14)
-
 **1.8**
 
 Issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**1.9**	
+
+Issues:	
+- GH-71: Add support for the installation of Microsoft .NET Core - Windows Server Hosting v3.1.5 (ISHServer.15)
+
 **1.8**
 
 Issues:

--- a/Source/Modules/ISHServer/metadata.ps1
+++ b/Source/Modules/ISHServer/metadata.ps1
@@ -15,5 +15,5 @@
 #>
 
 <#PSScriptInfo
-.VERSION 1.8
+.VERSION 1.9
 #>

--- a/Source/Modules/ISHServer/metadata.ps1
+++ b/Source/Modules/ISHServer/metadata.ps1
@@ -15,5 +15,5 @@
 #>
 
 <#PSScriptInfo
-.VERSION 1.9
+.VERSION 1.8
 #>


### PR DESCRIPTION
Reverts sdl/ISHServer#78 and Issue #76
Reverted since .NET Core 3.1 (Hosting Bundle) is no longer a requirement for 14.0.3